### PR TITLE
Othello API revision

### DIFF
--- a/src/othello_board.rs
+++ b/src/othello_board.rs
@@ -10,9 +10,27 @@ pub struct OthelloBoard {
 impl OthelloBoard {
     pub fn new() -> OthelloBoard {
         OthelloBoard {
+            black_stones: 0,
+            white_stones: 0,
+        }
+    }
+
+    pub fn standard() -> OthelloBoard {
+        OthelloBoard {
             black_stones: BLACK_START_POS,
             white_stones: WHITE_START_POS,
         }
+    }
+
+    pub fn from_state(black_stones: u64, white_stones: u64) -> Result<OthelloBoard, OthelloError> {
+        if black_stones & white_stones != 0 {
+            return Err(OthelloError::PiecesOverlapping);
+        }
+        let board = OthelloBoard {
+            black_stones,
+            white_stones,
+        };
+        Ok(board)
     }
 
     pub fn place_stone_unchecked(&mut self, stone: Stone, pos: u64) -> Result<(), OthelloError> {

--- a/src/othello_board.rs
+++ b/src/othello_board.rs
@@ -15,11 +15,15 @@ impl OthelloBoard {
         }
     }
 
-    pub fn place_stone_unchecked(&mut self, stone: Stone, pos: u64) {
+    pub fn place_stone_unchecked(&mut self, stone: Stone, pos: u64) -> Result<(), OthelloError> {
+        if self.bits_for(stone.flip()) & pos != 0 {
+            return Err(OthelloError::PiecesOverlapping);
+        }
         match stone {
             Stone::Black => self.black_stones |= pos,
             Stone::White => self.white_stones |= pos,
         }
+        Ok(())
     }
 
     pub fn place_stone(&mut self, stone: Stone, pos: u64) -> Result<(), OthelloError> {
@@ -110,6 +114,7 @@ impl OthelloBoard {
 pub enum OthelloError {
     IllegalMove,
     MultipleMovesAttempted,
+    PiecesOverlapping,
 }
 
 impl Direction {

--- a/src/othello_board.rs
+++ b/src/othello_board.rs
@@ -3,22 +3,22 @@ use crate::stone::Stone;
 
 #[derive(Clone)]
 pub struct OthelloBoard {
-    white_stones: u64,
     black_stones: u64,
+    white_stones: u64,
 }
 
 impl OthelloBoard {
     pub fn new() -> OthelloBoard {
         OthelloBoard {
-            white_stones: WHITE_START_POS,
             black_stones: BLACK_START_POS,
+            white_stones: WHITE_START_POS,
         }
     }
 
     pub fn place_stone_unchecked(&mut self, stone: Stone, pos: u64) {
         match stone {
-            Stone::White => self.white_stones |= pos,
             Stone::Black => self.black_stones |= pos,
+            Stone::White => self.white_stones |= pos,
         }
     }
 
@@ -51,15 +51,15 @@ impl OthelloBoard {
         }
 
         match stone {
-            Stone::White => {
-                self.white_stones |= mask;
-                self.white_stones |= pos;
-                self.black_stones ^= mask;
-            }
             Stone::Black => {
                 self.black_stones |= mask;
                 self.black_stones |= pos;
                 self.white_stones ^= mask;
+            }
+            Stone::White => {
+                self.white_stones |= mask;
+                self.white_stones |= pos;
+                self.black_stones ^= mask;
             }
         }
         Ok(())
@@ -67,8 +67,8 @@ impl OthelloBoard {
 
     pub fn bits_for(&self, stone: Stone) -> u64 {
         match stone {
-            Stone::White => self.white_stones,
             Stone::Black => self.black_stones,
+            Stone::White => self.white_stones,
         }
     }
 
@@ -94,14 +94,14 @@ impl OthelloBoard {
     }
 
     pub fn free_spaces(&self) -> u64 {
-        (!self.white_stones) & (!self.black_stones)
+        (!self.black_stones) & (!self.white_stones)
     }
 
     pub fn stone_at(&self, pos: u64) -> Option<Stone> {
-        if self.white_stones & pos > 0 {
-            Some(Stone::White)
-        } else if self.black_stones & pos > 0 {
+        if self.black_stones & pos > 0 {
             Some(Stone::Black)
+        } else if self.white_stones & pos > 0 {
+            Some(Stone::White)
         } else {
             None
         }
@@ -129,8 +129,8 @@ impl Direction {
     }
 }
 
-const WHITE_START_POS: u64 = 0x00_00_00_10_08_00_00_00;
 const BLACK_START_POS: u64 = 0x00_00_00_08_10_00_00_00;
+const WHITE_START_POS: u64 = 0x00_00_00_10_08_00_00_00;
 
 const LEFT_MASK: u64 = 0x80_80_80_80_80_80_80_80;
 const RIGHT_MASK: u64 = 0x01_01_01_01_01_01_01_01;

--- a/src/othello_board.rs
+++ b/src/othello_board.rs
@@ -24,7 +24,7 @@ impl OthelloBoard {
 
     pub fn place_stone(&mut self, stone: Stone, pos: u64) -> Result<(), OthelloError> {
         if pos.count_ones() != 1 {
-            return Err(OthelloError::IllegalMove);
+            return Err(OthelloError::MultipleMovesAttempted);
         }
         if !self.is_legal_move(stone, pos) {
             return Err(OthelloError::IllegalMove);
@@ -52,13 +52,11 @@ impl OthelloBoard {
 
         match stone {
             Stone::Black => {
-                self.black_stones |= mask;
-                self.black_stones |= pos;
+                self.black_stones |= mask | pos;
                 self.white_stones ^= mask;
             }
             Stone::White => {
-                self.white_stones |= mask;
-                self.white_stones |= pos;
+                self.white_stones |= mask | pos;
                 self.black_stones ^= mask;
             }
         }
@@ -111,6 +109,7 @@ impl OthelloBoard {
 #[derive(Debug)]
 pub enum OthelloError {
     IllegalMove,
+    MultipleMovesAttempted,
 }
 
 impl Direction {

--- a/src/othello_board.rs
+++ b/src/othello_board.rs
@@ -70,7 +70,7 @@ impl OthelloBoard {
         }
     }
 
-    fn is_legal_move(&self, stone: Stone, pos: u64) -> bool {
+    pub fn is_legal_move(&self, stone: Stone, pos: u64) -> bool {
         (pos & self.legal_moves_for(stone)) != 0
     }
 

--- a/src/othello_board.rs
+++ b/src/othello_board.rs
@@ -78,7 +78,7 @@ impl OthelloBoard {
 
     // https://core.ac.uk/download/pdf/33500946.pdf
     pub fn legal_moves_for(&self, stone: Stone) -> u64 {
-        let free_places = self.free_spaces();
+        let empty_cells = self.empty_cells();
         let current_bits = self.bits_for(stone);
         let opponent_bits = self.bits_for(stone.flip());
 
@@ -86,14 +86,14 @@ impl OthelloBoard {
         for dir in Direction::cardinals() {
             let mut candidates = dir.shift(current_bits) & opponent_bits;
             while candidates != 0 {
-                moves |= free_places & dir.shift(candidates);
+                moves |= empty_cells & dir.shift(candidates);
                 candidates = dir.shift(candidates) & opponent_bits;
             }
         }
         moves
     }
 
-    pub fn free_spaces(&self) -> u64 {
+    pub fn empty_cells(&self) -> u64 {
         (!self.black_stones) & (!self.white_stones)
     }
 

--- a/src/stone.rs
+++ b/src/stone.rs
@@ -1,15 +1,15 @@
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Stone {
-    White,
     Black,
+    White,
 }
 
 impl Stone {
     pub fn flip(&self) -> Stone {
         use Stone::*;
         match &self {
-            White => Black,
             Black => White,
+            White => Black,
         }
     }
 }

--- a/tests/perft.rs
+++ b/tests/perft.rs
@@ -7,7 +7,7 @@ macro_rules! perft_tests {
     $(
         #[test]
         fn $test_name() -> Result<(), TestError> {
-            let board = OthelloBoard::new();
+            let board = OthelloBoard::standard();
             let stone = Stone::Black;
             let depth = $depth;
             let target = perft_key(depth)?;


### PR DESCRIPTION
The API of the othello board was revised and a number of changes were introduced.

- Instead of stone `White` having "precedence" over stone `Black`, the
reverse is now true. Since black starts the game this is more consistent
with general expectations.
- `free_spaces` were renamed to `empty_cells`.
- `place_stone` now differentiates between two types of user error.
- `is_legal_move` is now part of the public API.
- `place_stone_unchecked` still needed some checking, despite its name. It is important to ensure that no stones overlap.
- The board can now be created in three different ways:
    - `new() -> OthelloBoard` 
    This creates a completely empty board without any stones on it.
    - `standard() -> OthelloBoard`
    This was previously the only way to create a board, pre-filled with the standard starting position. The name has been updated to reflect this fact.
    - `from_state(black: u64, white: u64) -> Result<OthelloBoard, OthelloError>`
    This function creates a new board from the supplied stone-positions. It ensures that no stones overlap in the created board and returns an error if any does.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>