### PR TITLE
Optional Serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ exclude = [
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[profile.test]
-opt-level = 3
+[dependencies]
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 lazy_static = "1.4.0"
@@ -24,3 +24,6 @@ criterion = "0.3.3"
 [[bench]]
 name = "othello_board"
 harness = false
+
+[profile.test]
+opt-level = 3

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Magpie is intentionally minimalistic and delegates some basic functionality to t
 
 The library is intended to be consumed behind another abstraction which may keep track of the next player to play or cache various calculations.
 
+## Table of Contents
+- [Documentation](#documentation)
+- [Usage](#usage)
+- [Crate Features](#crate-features)
+
 ## Documentation
 
 Documentation is hosted on [docs.rs](https://docs.rs/magpie/)
@@ -47,4 +52,13 @@ pub fn play(...) {
     let white = board.bits_for(Stone::White).count_ones();
     println!("Game finished with {} - {} (black - white)", black, white);
 }
+```
+
+## Crate features
+
+Serialization with [Serde](https://serde.rs/) is not supported by default. If you want to opt into using magpie with Serde you can enable a feature flag. Simply change your magpie dependency to the following:
+
+```toml
+[dependencies]
+magpie = {version = "0.1.0", features = ["serde"]}
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,17 @@
 //! the user enough access to the internals to satisfy a wide array of
 //! applications in a safe way.
 //!
+//! Serialization with [Serde](https://serde.rs/) is not supported by default.
+//! If you want to opt into using magpie with Serde you can enable a feature
+//! flag. Simply change your magpie dependency to the following:
+//!
+//! ```toml
+//! [dependencies]
+//! magpie = {version = "0.1.0", features = ["serde"]}
+//! ```
+//!
 //! [`Wikipedia`]: https://en.wikipedia.org/wiki/Bitboard
+//! [`Serde`]: https://serde.rs
 
 mod direction;
 /// Represents an Othello board and provides convenient methods to safely manipulate it.

--- a/src/othello_board.rs
+++ b/src/othello_board.rs
@@ -1,6 +1,11 @@
 use crate::direction::Direction;
 use crate::stone::Stone;
 
+#[cfg(feature = "serde")]
+use serde::Deserialize;
+#[cfg(feature = "serde")]
+use serde::Serialize;
+
 /// Represents an Othello board and provides convenient methods to safely manipulate it.
 ///
 /// The board is represented by two bitboards, one for black player and one for
@@ -35,7 +40,8 @@ use crate::stone::Stone;
 /// 8 | 56 | 57 | 58 | 59 | 60 | 61 | 62 | 63 |
 ///   +----+----+----+----+----+----+----+----+
 /// ```
-#[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct OthelloBoard {
     black_stones: u64,
     white_stones: u64,

--- a/src/stone.rs
+++ b/src/stone.rs
@@ -1,5 +1,11 @@
+#[cfg(feature = "serde")]
+use serde::Deserialize;
+#[cfg(feature = "serde")]
+use serde::Serialize;
+
 /// Enum that represents the two different possible stone colors available on a standard Othello board.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Stone {
     Black,
     White,


### PR DESCRIPTION
Added optional Serde support. Enabling a feature flag will allow the user to serialize to whatever format they wish, and back.

Currently, the CI process does not check the build status of this feature. This should probably be fixed in the future. An issue has been raised: https://github.com/LimeEng/magpie/issues/5

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>