### PR TITLE
Optimized legal move check

### DIFF
--- a/src/othello_board.rs
+++ b/src/othello_board.rs
@@ -240,7 +240,10 @@ impl OthelloBoard {
         }
     }
 
-    /// Checks whether or not a move is valid for the specified player
+    /// Checks whether or not a move is valid for the specified player.
+    ///
+    /// The specified bitboard must have one and only one bit set. If this is
+    /// not true, the function will always return false.
     ///
     /// # Examples
     /// ```rust
@@ -251,7 +254,24 @@ impl OthelloBoard {
     /// assert_eq!(board.is_legal_move(Stone::Black, 1_u64), false);
     /// ```
     pub fn is_legal_move(&self, stone: Stone, pos: u64) -> bool {
-        (pos & self.legal_moves_for(stone)) != 0
+        if pos.count_ones() != 1 {
+            return false;
+        }
+        let current_bits = self.bits_for(stone);
+        let opponent_bits = self.bits_for(stone.flip());
+
+        for dir in Direction::cardinals() {
+            let mut candidates = dir.shift(pos) & opponent_bits;
+            while candidates != 0 {
+                candidates = dir.shift(candidates);
+                let is_own_piece = candidates & current_bits != 0;
+                candidates &= opponent_bits;
+                if candidates == 0 && is_own_piece {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     /// Calculates and returns the set of all legal moves for the specified player.

--- a/tests/othello_board.rs
+++ b/tests/othello_board.rs
@@ -1,0 +1,58 @@
+use magpie::othello_board::OthelloBoard;
+use magpie::stone::Stone;
+
+#[test]
+fn legal_move_check_one_valid() {
+    let board = board_one_legal_move();
+    let pos = 0x00_00_00_00_08_00_00_00;
+    assert_eq!(true, board.is_legal_move(Stone::Black, pos));
+}
+
+#[test]
+fn legal_move_check_one_valid_one_invalid() {
+    let board = board_one_legal_move();
+    // Note the leading 8
+    let pos = 0x80_00_00_00_08_00_00_00;
+    assert_eq!(false, board.is_legal_move(Stone::Black, pos));
+}
+
+#[test]
+fn legal_move_check_two_valid() {
+    let board = board_two_legal_moves();
+    let pos = 0x80_00_00_00_00_00_00_01;
+    assert_eq!(false, board.is_legal_move(Stone::Black, pos));
+}
+
+#[test]
+fn legal_move_check_none_valid() {
+    let board = board_no_legal_moves();
+    let pos = 0x00_00_00_00_08_00_00_00;
+    assert_eq!(false, board.is_legal_move(Stone::Black, pos));
+}
+
+// Returns a board with only one legal move for black, that is, the following
+// move represented as a bitboard: 0x00_00_00_00_08_00_00_00.
+fn board_one_legal_move() -> OthelloBoard {
+    let black_pos = 0x88_01_00_00_81_00_00_49;
+    let white_pos = 0x00_48_2a_1c_76_1c_2a_00;
+
+    OthelloBoard::from_state(black_pos, white_pos).unwrap()
+}
+
+// Returns a board with only two legal moves for black, that is, the following
+// moves represented as a bitboard: 0x80_00_00_00_00_00_00_01.
+fn board_two_legal_moves() -> OthelloBoard {
+    let black_pos = 0x01_00_00_00_00_00_00_00;
+    let white_pos = 0x7e_01_01_01_01_01_01_00;
+
+    OthelloBoard::from_state(black_pos, white_pos).unwrap()
+}
+
+fn board_no_legal_moves() -> OthelloBoard {
+    let board = board_one_legal_move();
+
+    let black_pos = 0;
+    let white_pos = board.bits_for(Stone::White) | board.bits_for(Stone::Black);
+
+    OthelloBoard::from_state(black_pos, white_pos).unwrap()
+}


### PR DESCRIPTION
Optimizes the legal move check. This significantly improves performance and almost halves the time it makes to make a move.

Closes #7 

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>