### PR TITLE
Enabled testing with Serde

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Empty string means no features will be enabled
+        features: ["", "--features serde"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -26,8 +30,8 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - name: Run tests
-        run: cargo test --verbose
+      - name: Run tests ${{ matrix.features }}
+        run: cargo test --verbose ${{ matrix.features }}
 
   fmt:
     name: fmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ serde_json = "1.0.60"
 name = "serde"
 required-features = ["serde"]
 
+[[test]]
+name = "serde"
+required-features = ["serde"]
+
 [[bench]]
 name = "othello_board"
 harness = false

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,4 @@
+#[test]
+fn serde_placeholder() {
+    println!("Testing with Serde!");
+}


### PR DESCRIPTION
The CI process will now also test the library with the Serde feature flag enabled. This will be especially important when #13 gets resolved to prevent regressions.

Closes #5

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>