### PR TITLE
Trait implementations

### DIFF
--- a/benches/othello_board.rs
+++ b/benches/othello_board.rs
@@ -2,6 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use magpie::othello_board::OthelloBoard;
 use magpie::othello_board::PositionExt;
 use magpie::stone::Stone;
+use std::convert::TryFrom;
 
 fn bench_clone(c: &mut Criterion) {
     let board = OthelloBoard::standard();
@@ -58,12 +59,12 @@ fn board_for_place_stone() -> OthelloBoard {
     let black_pos = 0x88_01_00_00_81_00_00_49;
     let white_pos = 0x00_48_2a_1c_76_1c_2a_00;
 
-    OthelloBoard::from_state(black_pos, white_pos).unwrap()
+    OthelloBoard::try_from((black_pos, white_pos)).unwrap()
 }
 
 fn board_for_legal_moves() -> OthelloBoard {
     let black_pos = 0x00_11_66_0c_3c_2c_00_00;
     let white_pos = 0x00_66_00_52_40_52_56_00;
 
-    OthelloBoard::from_state(black_pos, white_pos).unwrap()
+    OthelloBoard::try_from((black_pos, white_pos)).unwrap()
 }

--- a/tests/othello_board.rs
+++ b/tests/othello_board.rs
@@ -1,5 +1,6 @@
 use magpie::othello_board::OthelloBoard;
 use magpie::stone::Stone;
+use std::convert::TryFrom;
 
 #[test]
 fn legal_move_check_one_valid() {
@@ -36,7 +37,7 @@ fn board_one_legal_move() -> OthelloBoard {
     let black_pos = 0x88_01_00_00_81_00_00_49;
     let white_pos = 0x00_48_2a_1c_76_1c_2a_00;
 
-    OthelloBoard::from_state(black_pos, white_pos).unwrap()
+    OthelloBoard::try_from((black_pos, white_pos)).unwrap()
 }
 
 // Returns a board with only two legal moves for black, that is, the following
@@ -45,7 +46,7 @@ fn board_two_legal_moves() -> OthelloBoard {
     let black_pos = 0x01_00_00_00_00_00_00_00;
     let white_pos = 0x7e_01_01_01_01_01_01_00;
 
-    OthelloBoard::from_state(black_pos, white_pos).unwrap()
+    OthelloBoard::try_from((black_pos, white_pos)).unwrap()
 }
 
 fn board_no_legal_moves() -> OthelloBoard {
@@ -54,5 +55,5 @@ fn board_no_legal_moves() -> OthelloBoard {
     let black_pos = 0;
     let white_pos = board.bits_for(Stone::White) | board.bits_for(Stone::Black);
 
-    OthelloBoard::from_state(black_pos, white_pos).unwrap()
+    OthelloBoard::try_from((black_pos, white_pos)).unwrap()
 }


### PR DESCRIPTION
Implemented [`TryFrom`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html) and [`Default`](https://doc.rust-lang.org/std/default/trait.Default.html).

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>