### PR TITLE
Unsound deserialization bug

### DIFF
--- a/src/stone.rs
+++ b/src/stone.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "serde")]
-use serde::Deserialize;
-#[cfg(feature = "serde")]
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Enum that represents the two different possible stone colors available on a standard Othello board.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,4 +1,25 @@
+use magpie::othello_board::OthelloBoard;
+use magpie::stone::Stone;
+use serde_json::Result;
+
 #[test]
-fn serde_placeholder() {
-    println!("Testing with Serde!");
+fn serde_legal_deserialization() -> Result<()> {
+    let board = OthelloBoard::standard();
+    let json = serde_json::to_string_pretty(&board)?;
+    let board: OthelloBoard = serde_json::from_str(&json)?;
+
+    assert_eq!(board.legal_moves_for(Stone::Black).count_ones(), 4);
+
+    Ok(())
+}
+
+#[test]
+fn serde_illegal_deserialization() {
+    let json = r#"{
+        "black_stones": 111111111,
+        "white_stones": 111111111
+    }"#;
+
+    let board = serde_json::from_str::<OthelloBoard>(&json);
+    assert!(board.is_err(), "The deserialization should not succeed");
 }


### PR DESCRIPTION
The OthelloBoard struct is careful to validate the board representation to ensure that no stones overlap with each other. Since all other operations on the board rely on this property it is of utmost importance to not violate it. Unfortunately, this validation was not performed when deserializing with Serde, as outlined in #13.

The first obvious solution was to write a custom deserializer which performed the check. But that was avoided by introducing a shadow type which in turn utilized the `TryFrom<(u64, u64)>` trait. The shadow type could later be converted to the proper type. 

Two basic tests were added to avoid regressions in this area.

Closes #13

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>