### PR TITLE
CI status badge correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![CI status](https://github.com/LimeEng/othello/workflows/CI/badge.svg)
+![CI status](https://github.com/LimeEng/magpie/workflows/CI/badge.svg)
 [![Latest version](https://img.shields.io/crates/v/magpie.svg)](https://crates.io/crates/magpie)
 
 # Magpie


### PR DESCRIPTION
The CI status badge pointed to the wrong repository. This has now been fixed.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>