### PR TITLE
Othello module

### DIFF
--- a/benches/othello_board.rs
+++ b/benches/othello_board.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use magpie::othello_board::OthelloBoard;
-use magpie::othello_board::PositionExt;
-use magpie::stone::Stone;
+use magpie::othello::OthelloBoard;
+use magpie::othello::PositionExt;
+use magpie::othello::Stone;
 use std::convert::TryFrom;
 
 fn bench_clone(c: &mut Criterion) {

--- a/examples/human_vs_ai/agent/human_agent.rs
+++ b/examples/human_vs_ai/agent/human_agent.rs
@@ -1,8 +1,8 @@
 use crate::agent::Action;
 use crate::agent::Agent;
 use crate::coord::Coord;
-use magpie::othello_board::OthelloBoard;
-use magpie::stone::Stone;
+use magpie::othello::OthelloBoard;
+use magpie::othello::Stone;
 use std::io;
 use std::io::Write;
 

--- a/examples/human_vs_ai/agent/mod.rs
+++ b/examples/human_vs_ai/agent/mod.rs
@@ -1,5 +1,5 @@
-use magpie::othello_board::OthelloBoard;
-use magpie::stone::Stone;
+use magpie::othello::OthelloBoard;
+use magpie::othello::Stone;
 
 pub mod human_agent;
 pub mod random_agent;

--- a/examples/human_vs_ai/agent/random_agent.rs
+++ b/examples/human_vs_ai/agent/random_agent.rs
@@ -1,8 +1,8 @@
 use crate::agent::Action;
 use crate::agent::Agent;
-use magpie::othello_board::OthelloBoard;
-use magpie::othello_board::PositionExt;
-use magpie::stone::Stone;
+use magpie::othello::OthelloBoard;
+use magpie::othello::PositionExt;
+use magpie::othello::Stone;
 use rand::seq::SliceRandom;
 
 /// Plays completely randomly. If no legal moves are available, passes their

--- a/examples/human_vs_ai/main.rs
+++ b/examples/human_vs_ai/main.rs
@@ -3,8 +3,8 @@ use crate::agent::Agent;
 use crate::coord::Coord;
 use agent::human_agent::HumanAgent;
 use agent::random_agent::RandomAgent;
-use magpie::othello_board::OthelloBoard;
-use magpie::stone::Stone;
+use magpie::othello::OthelloBoard;
+use magpie::othello::Stone;
 use std::convert::TryFrom;
 
 pub mod agent;

--- a/examples/human_vs_ai/util.rs
+++ b/examples/human_vs_ai/util.rs
@@ -1,6 +1,6 @@
 use crate::coord::Coord;
-use magpie::othello_board::OthelloBoard;
-use magpie::stone::Stone;
+use magpie::othello::OthelloBoard;
+use magpie::othello::Stone;
 use std::convert::TryFrom;
 
 /// Prints the specified board with optional legal moves included

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -1,5 +1,5 @@
-use magpie::othello_board::OthelloBoard;
-use magpie::stone::Stone;
+use magpie::othello::OthelloBoard;
+use magpie::othello::Stone;
 use serde::{Deserialize, Serialize};
 use serde_json::Result;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,5 @@
 //! [`Serde`]: https://serde.rs
 
 mod direction;
-/// Represents an Othello board and provides convenient methods to safely manipulate it.
-pub mod othello_board;
-/// An enum that represents the two stone colors players can play with.
-pub mod stone;
+/// Contains structs and functions that are useful when playing Othello.
+pub mod othello;

--- a/src/othello/mod.rs
+++ b/src/othello/mod.rs
@@ -1,0 +1,9 @@
+/// Represents an Othello board and provides convenient methods to safely manipulate it.
+mod othello_board;
+// /// An enum that represents the two stone colors players can play with.
+mod stone;
+
+pub use othello_board::OthelloBoard;
+pub use othello_board::OthelloError;
+pub use othello_board::PositionExt;
+pub use stone::Stone;

--- a/src/othello/othello_board.rs
+++ b/src/othello/othello_board.rs
@@ -1,5 +1,5 @@
 use crate::direction::Direction;
-use crate::stone::Stone;
+use crate::othello::Stone;
 use std::convert::TryFrom;
 
 #[cfg(feature = "serde")]
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 /// operations, like [`place_stone`] expects that the argument bitboard only
 /// has a single bit set and will return an error if that is false.
 ///
-/// [`place_stone`]: crate::othello_board::OthelloBoard::place_stone
+/// [`place_stone`]: crate::othello::OthelloBoard::place_stone
 ///
 /// ```text
 ///     A    B    C    D    E    F    G    H
@@ -57,11 +57,11 @@ impl OthelloBoard {
     /// This can be useful for setting up specific scenarios but for most
     /// users, the [`standard`] constructor will be more useful.
     ///
-    /// [`standard`]: crate::othello_board::OthelloBoard::standard
+    /// [`standard`]: crate::othello::OthelloBoard::standard
     ///
     /// # Examples
     /// ```rust
-    /// use magpie::othello_board::OthelloBoard;
+    /// use magpie::othello::OthelloBoard;
     ///
     /// let board = OthelloBoard::empty();
     /// ```
@@ -91,7 +91,7 @@ impl OthelloBoard {
     /// ```
     /// # Examples
     /// ```rust
-    /// use magpie::othello_board::OthelloBoard;
+    /// use magpie::othello::OthelloBoard;
     ///
     /// let board = OthelloBoard::standard();
     /// ```
@@ -111,12 +111,12 @@ impl OthelloBoard {
     /// placed on top of a stone of the opposite color, and if so, returns an
     /// error leaving the board untouched.
     ///
-    ///  [`place_stone`]: crate::othello_board::OthelloBoard::place_stone
+    ///  [`place_stone`]: crate::othello::OthelloBoard::place_stone
     ///
     /// # Examples
     /// ```rust
-    /// use magpie::othello_board::OthelloBoard;
-    /// use magpie::stone::Stone;
+    /// use magpie::othello::OthelloBoard;
+    /// use magpie::othello::Stone;
     ///
     /// let mut board = OthelloBoard::empty();
     /// board.place_stone_unchecked(Stone::Black, 1_u64).unwrap()
@@ -139,9 +139,9 @@ impl OthelloBoard {
     ///
     /// # Examples
     /// ```rust
-    /// use magpie::othello_board::OthelloBoard;
-    /// use magpie::othello_board::PositionExt;
-    /// use magpie::stone::Stone;
+    /// use magpie::othello::OthelloBoard;
+    /// use magpie::othello::PositionExt;
+    /// use magpie::othello::Stone;
     ///
     /// let mut board = OthelloBoard::standard();
     /// let player = Stone::Black;
@@ -197,12 +197,12 @@ impl OthelloBoard {
     /// The returned bitboard represents the Othello board. For a more detailed
     /// description, refer to the documentation of the [`OthelloBoard struct`].
     ///
-    /// [`OthelloBoard struct`]: crate::othello_board::OthelloBoard
+    /// [`OthelloBoard struct`]: crate::othello::OthelloBoard
     ///
     /// # Examples
     /// ```rust
-    /// use magpie::othello_board::OthelloBoard;
-    /// use magpie::stone::Stone;
+    /// use magpie::othello::OthelloBoard;
+    /// use magpie::othello::Stone;
     ///
     /// let board = OthelloBoard::standard();
     /// let black = board.bits_for(Stone::Black);
@@ -224,8 +224,8 @@ impl OthelloBoard {
     ///
     /// # Examples
     /// ```rust
-    /// use magpie::othello_board::OthelloBoard;
-    /// use magpie::stone::Stone;
+    /// use magpie::othello::OthelloBoard;
+    /// use magpie::othello::Stone;
     ///
     /// let board = OthelloBoard::standard();
     /// assert_eq!(board.is_legal_move(Stone::Black, 1_u64), false);
@@ -256,12 +256,12 @@ impl OthelloBoard {
     /// The returned bitboard represents the Othello board. For a more detailed
     /// description, refer to the documentation of the [`OthelloBoard struct`].
     ///
-    /// [`OthelloBoard struct`]: crate::othello_board::OthelloBoard
+    /// [`OthelloBoard struct`]: crate::othello::OthelloBoard
     ///
     /// # Examples
     /// ```rust
-    /// use magpie::othello_board::OthelloBoard;
-    /// use magpie::stone::Stone;
+    /// use magpie::othello::OthelloBoard;
+    /// use magpie::othello::Stone;
     ///
     /// let board = OthelloBoard::standard();
     /// let stone = Stone::Black;
@@ -288,11 +288,11 @@ impl OthelloBoard {
     /// The returned bitboard represents the Othello board. For a more detailed
     /// description, refer to the documentation of the [`OthelloBoard struct`]
     ///
-    /// [`OthelloBoard struct`]: crate::othello_board::OthelloBoard
+    /// [`OthelloBoard struct`]: crate::othello::OthelloBoard
     ///
     /// # Examples
     /// ```rust
-    /// use magpie::othello_board::OthelloBoard;
+    /// use magpie::othello::OthelloBoard;
     ///
     /// let board = OthelloBoard::standard();
     /// println!("Number of free cells: {}", board.empty_cells().count_ones());
@@ -308,8 +308,8 @@ impl OthelloBoard {
     ///
     /// # Examples
     /// ```rust
-    /// use magpie::othello_board::OthelloBoard;
-    /// use magpie::stone::Stone;
+    /// use magpie::othello::OthelloBoard;
+    /// use magpie::othello::Stone;
     ///
     /// let board = OthelloBoard::standard();
     /// let pos = 0x8000000;
@@ -358,7 +358,7 @@ impl Default for OthelloBoard {
     ///
     /// Simply delegates to the [`standard`] constructor.
     ///
-    /// [`standard`]: crate::othello_board::OthelloBoard::standard
+    /// [`standard`]: crate::othello::OthelloBoard::standard
     fn default() -> Self {
         OthelloBoard::standard()
     }
@@ -373,8 +373,8 @@ impl TryFrom<(u64, u64)> for OthelloBoard {
     ///
     /// # Examples
     /// ```rust
-    /// use magpie::othello_board::OthelloBoard;
-    /// use magpie::stone::Stone;
+    /// use magpie::othello::OthelloBoard;
+    /// use magpie::othello::Stone;
     /// use std::convert::TryFrom;
     ///
     /// let board = OthelloBoard::standard();
@@ -452,9 +452,9 @@ pub trait PositionExt: Sized {
     ///
     /// # Examples
     /// ```rust
-    /// use magpie::othello_board::OthelloBoard;
-    /// use magpie::othello_board::PositionExt;
-    /// use magpie::stone::Stone;
+    /// use magpie::othello::OthelloBoard;
+    /// use magpie::othello::PositionExt;
+    /// use magpie::othello::Stone;
     ///
     /// let mut board = OthelloBoard::standard();
     /// let player = Stone::Black;

--- a/src/othello/stone.rs
+++ b/src/othello/stone.rs
@@ -14,7 +14,7 @@ impl Stone {
     ///
     /// # Examples
     /// ```rust
-    /// use magpie::stone::Stone;
+    /// use magpie::othello::Stone;
     ///
     /// let stone = Stone::Black;
     /// assert_eq!(stone.flip(), Stone::White);

--- a/tests/othello_board.rs
+++ b/tests/othello_board.rs
@@ -1,5 +1,5 @@
-use magpie::othello_board::OthelloBoard;
-use magpie::stone::Stone;
+use magpie::othello::OthelloBoard;
+use magpie::othello::Stone;
 use std::convert::TryFrom;
 
 #[test]

--- a/tests/perft.rs
+++ b/tests/perft.rs
@@ -1,6 +1,6 @@
-use magpie::othello_board::OthelloBoard;
-use magpie::othello_board::PositionExt;
-use magpie::stone::Stone;
+use magpie::othello::OthelloBoard;
+use magpie::othello::PositionExt;
+use magpie::othello::Stone;
 
 macro_rules! perft_tests {
     ($($test_name:ident: $depth:expr,)*) => {

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,5 +1,5 @@
-use magpie::othello_board::OthelloBoard;
-use magpie::stone::Stone;
+use magpie::othello::OthelloBoard;
+use magpie::othello::Stone;
 use serde_json::Result;
 
 #[test]

--- a/tests/stone.rs
+++ b/tests/stone.rs
@@ -1,4 +1,4 @@
-use magpie::stone::Stone;
+use magpie::othello::Stone;
 
 #[test]
 fn stone_flip_equality() -> Result<(), TestError> {


### PR DESCRIPTION
Reorganized the library to avoid repetitive imports.
Before:
```rust
magpie::othello_board::OthelloBoard;
magpie::stone::Stone;
``` 

After:
```rust
magpie::othello::OthelloBoard;
magpie::othello::Stone;
``` 

It is grouped more intuitively as you would expect to find the `Stone` enum under the othello module instead of having its very own, for example.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>