### PR TITLE
Bumped version and updated dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magpie"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Emil Englesson <englesson.emil@gmail.com>"]
 edition = "2018"
 description = "A simple Othello library built with bitboards"
@@ -19,8 +19,8 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.3.3"
-rand = "0.7.3"
-unicode-segmentation = "1.6.0"
+rand = "0.8.0"
+unicode-segmentation = "1.7.1"
 serde_json = "1.0.60"
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-magpie = "0.3.0"
+magpie = "0.4.0"
 ```
 
 ## Crate features
@@ -34,7 +34,7 @@ Serialization with [Serde](https://serde.rs/) is not supported by default. If yo
 
 ```toml
 [dependencies]
-magpie = {version = "0.3.0", features = ["serde"]}
+magpie = {version = "0.4.0", features = ["serde"]}
 ```
 
 ## Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! magpie = {version = "0.3.0", features = ["serde"]}
+//! magpie = {version = "0.4.0", features = ["serde"]}
 //! ```
 //!
 //! [`Wikipedia`]: https://en.wikipedia.org/wiki/Bitboard


### PR DESCRIPTION
Updated dev-dependencies and bumped version in Cargo.toml and related docs.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>