### PR TITLE
Remove stones unchecked

### DIFF
--- a/src/othello/mod.rs
+++ b/src/othello/mod.rs
@@ -1,6 +1,6 @@
 /// Represents an Othello board and provides convenient methods to safely manipulate it.
 mod othello_board;
-// /// An enum that represents the two stone colors players can play with.
+/// An enum that represents the two stone colors players can play with.
 mod stone;
 
 pub use othello_board::OthelloBoard;

--- a/src/othello/othello_board.rs
+++ b/src/othello/othello_board.rs
@@ -102,7 +102,7 @@ impl OthelloBoard {
         }
     }
 
-    /// Places a stone in the specified position, which may be several at a time.
+    /// Places stones in the specified positions.
     ///
     /// Unlike the similar [`place_stone`] function, this function places no
     /// restrictions on the `pos` argument. Multiple stones may be placed at
@@ -130,6 +130,27 @@ impl OthelloBoard {
             Stone::White => self.white_stones |= pos,
         }
         Ok(())
+    }
+
+    /// Removes stones in the specified positions.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use magpie::othello::OthelloBoard;
+    /// use magpie::othello::Stone;
+    ///
+    /// let mut board = OthelloBoard::standard();
+    /// let black_stones = board.bits_for(Stone::Black);
+    /// let white_stones = board.bits_for(Stone::White);
+    /// board.remove_stone_unchecked(Stone::Black, black_stones);
+    /// board.remove_stone_unchecked(Stone::White, white_stones);
+    /// assert_eq!(OthelloBoard::empty(), board);
+    /// ```
+    pub fn remove_stone_unchecked(&mut self, stone: Stone, pos: u64) {
+        match stone {
+            Stone::Black => self.black_stones &= !pos,
+            Stone::White => self.white_stones &= !pos,
+        }
     }
 
     /// Places a stone in the specified position and updates the board accordingly.


### PR DESCRIPTION
Added a method to remove stones from the board. This is the complement to `place_stone_unchecked` which means that no checks will be performed to ensure that rules are followed. However, just as `place_stone_unchecked`, the board will be left in a valid and playable state after any operation.

Closes #22 

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>