### PR TITLE
Tweaking tests

### DIFF
--- a/src/direction.rs
+++ b/src/direction.rs
@@ -42,33 +42,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn direction_iter_size() -> Result<(), TestError> {
+    fn direction_iter_size() {
         use Direction::*;
         let correct_order = vec![N, NE, E, SE, S, SW, W, NW];
         let count = Direction::cardinals().take(100).count();
 
-        if count != correct_order.len() {
-            return Err(TestError::DirectionCardinalsWrongSize);
-        }
-        Ok(())
+        assert_eq!(correct_order.len(), count);
     }
 
     #[test]
-    fn direction_iter_order() -> Result<(), TestError> {
+    fn direction_iter_order() {
         use Direction::*;
         let correct_order = vec![N, NE, E, SE, S, SW, W, NW];
         let equal_count = Direction::cardinals()
             .zip(correct_order.iter())
             .filter(|(a, b)| a == *b)
             .count();
-        if correct_order.len() != equal_count {
-            return Err(TestError::DirectionCardinalsWrongOrder);
-        }
-        Ok(())
-    }
-    #[derive(Debug)]
-    enum TestError {
-        DirectionCardinalsWrongOrder,
-        DirectionCardinalsWrongSize,
+
+        assert_eq!(correct_order.len(), equal_count);
     }
 }

--- a/src/othello/othello_board.rs
+++ b/src/othello/othello_board.rs
@@ -229,7 +229,7 @@ impl OthelloBoard {
     /// let black = board.bits_for(Stone::Black);
     /// let white = board.bits_for(Stone::White);
     /// // The two bitboards do not intersect
-    /// assert_eq!(black & white, 0);
+    /// assert_eq!(0, black & white);
     /// ```
     pub fn bits_for(&self, stone: Stone) -> u64 {
         match stone {
@@ -249,7 +249,7 @@ impl OthelloBoard {
     /// use magpie::othello::Stone;
     ///
     /// let board = OthelloBoard::standard();
-    /// assert_eq!(board.is_legal_move(Stone::Black, 1_u64), false);
+    /// assert_eq!(false, board.is_legal_move(Stone::Black, 1_u64));
     /// ```
     pub fn is_legal_move(&self, stone: Stone, pos: u64) -> bool {
         if pos.count_ones() != 1 {

--- a/src/othello/stone.rs
+++ b/src/othello/stone.rs
@@ -17,7 +17,7 @@ impl Stone {
     /// use magpie::othello::Stone;
     ///
     /// let stone = Stone::Black;
-    /// assert_eq!(stone.flip(), Stone::White);
+    /// assert_eq!(Stone::White, stone.flip());
     /// ```
     pub fn flip(&self) -> Stone {
         use Stone::*;

--- a/tests/perft.rs
+++ b/tests/perft.rs
@@ -20,6 +20,25 @@ macro_rules! perft_tests {
     }
 }
 
+macro_rules! ignored_perft_tests {
+    ($($test_name:ident: $depth:expr,)*) => {
+    $(
+        #[ignore]
+        #[test]
+        fn $test_name() -> Result<(), TestError> {
+            let board = OthelloBoard::standard();
+            let stone = Stone::Black;
+            let target = perft_key($depth)?;
+            let nodes = perft(&board, stone, false, $depth);
+            if target != nodes {
+                return Err(TestError::PerftTargetMissed);
+            }
+            Ok(())
+        }
+    )*
+    }
+}
+
 perft_tests! {
     perft_1: 1,
     perft_2: 2,
@@ -28,13 +47,18 @@ perft_tests! {
     perft_5: 5,
     perft_6: 6,
     perft_7: 7,
+}
+
+ignored_perft_tests! {
     // Too expensive to run regularly.
-    // TODO: add #[ignore] to these tests
-    // perft_8: 8,
-    // perft_9: 9,
-    // perft_10: 10,
-    // perft_11: 11,
-    // perft_12: 12,
+    perft_8: 8,
+    perft_9: 9,
+    perft_10: 10,
+    perft_11: 11,
+    perft_12: 12,
+    // Too ridiculously expensive to run at all.
+    // perft_13: 13,
+    // perft_14: 14,
 }
 
 fn perft_key(depth: u8) -> Result<u64, TestError> {
@@ -51,6 +75,8 @@ fn perft_key(depth: u8) -> Result<u64, TestError> {
         10 => 24571284,
         11 => 212258800,
         12 => 1939886636,
+        13 => 18429641748,
+        14 => 184042084512,
         _ => return Err(TestError::PerftDepthTooLarge),
     })
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -8,16 +8,17 @@ fn serde_legal_deserialization() -> Result<()> {
     let json = serde_json::to_string_pretty(&board)?;
     let board: OthelloBoard = serde_json::from_str(&json)?;
 
-    assert_eq!(board.legal_moves_for(Stone::Black).count_ones(), 4);
+    assert_eq!(OthelloBoard::standard(), board);
 
     Ok(())
 }
 
 #[test]
 fn serde_illegal_deserialization() {
+    // These two numbers share a bit with value 1 in the same position
     let json = r#"{
-        "black_stones": 111111111,
-        "white_stones": 111111111
+        "black_stones": 123456789,
+        "white_stones": 1
     }"#;
 
     let board = serde_json::from_str::<OthelloBoard>(&json);

--- a/tests/stone.rs
+++ b/tests/stone.rs
@@ -1,15 +1,7 @@
 use magpie::othello::Stone;
 
 #[test]
-fn stone_flip_equality() -> Result<(), TestError> {
+fn stone_flip_equality() {
     let stone = Stone::Black;
-    if stone.flip().flip() != stone {
-        return Err(TestError::StoneNotEqual);
-    }
-    Ok(())
-}
-
-#[derive(Debug)]
-enum TestError {
-    StoneNotEqual,
+    assert_eq!(stone, stone.flip().flip());
 }


### PR DESCRIPTION
Various small tweaks to test-related code. Most notably, perft tests with deeper depths can are now ignored instead of simply commented out. This means that it is possible to selectively run these more expensive tests when needed.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>