### PR TITLE
Quickcheck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ criterion = "0.3.3"
 rand = "0.8.0"
 unicode-segmentation = "1.7.1"
 serde_json = "1.0.60"
+quickcheck = "1.0.2"
+quickcheck_macros = "1.0.0"
+lazy_static = "1.4.0"
 
 [[example]]
 name = "serde"

--- a/src/othello/othello_board.rs
+++ b/src/othello/othello_board.rs
@@ -258,6 +258,11 @@ impl OthelloBoard {
         let current_bits = self.bits_for(stone);
         let opponent_bits = self.bits_for(stone.flip());
 
+        // Pos must be on an empty square to be legal
+        if pos & (current_bits | opponent_bits) != 0 {
+            return false;
+        }
+
         for dir in Direction::cardinals() {
             let mut candidates = dir.shift(pos) & opponent_bits;
             while candidates != 0 {

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1,0 +1,136 @@
+use lazy_static::lazy_static;
+use magpie::othello::{OthelloBoard, OthelloError, PositionExt, Stone};
+use quickcheck::{Arbitrary, Gen};
+use quickcheck_macros::quickcheck;
+use std::{collections::HashSet, convert::TryFrom, iter::successors};
+
+lazy_static! {
+    static ref MASKS: Vec<u64> = {
+        successors(Some(1_u64), |n| {
+            if *n == 1_u64 << 63 {
+                None
+            } else {
+                Some(n << 1)
+            }
+        })
+        .collect()
+    };
+}
+
+#[quickcheck]
+fn legal_moves_should_place(board: ShadowOthelloBoard) {
+    // Check so that all legal moves returned can actually be placed
+    let board = OthelloBoard::try_from(board).unwrap();
+    let stone = Stone::Black;
+
+    let result = board
+        .legal_moves_for(stone)
+        .positions()
+        .map(|pos| board.clone().place_stone(stone, pos))
+        .all(|result| result.is_ok());
+    assert!(result);
+}
+
+#[quickcheck]
+fn illegal_moves_should_not_place(board: ShadowOthelloBoard) {
+    // Check so that all moves not contained in the set of legal moves
+    // cannot actually be placed
+    let board = OthelloBoard::try_from(board).unwrap();
+    let stone = Stone::Black;
+
+    let legal_positions: HashSet<u64> = board.legal_moves_for(stone).positions().collect();
+
+    let failed = MASKS
+        .iter()
+        .filter(|pos| !legal_positions.contains(pos))
+        .map(|pos| board.clone().place_stone(stone, *pos))
+        .any(|result| result.is_ok());
+
+    assert!(!failed);
+}
+
+#[quickcheck]
+fn legal_moves_should_be_legal(board: ShadowOthelloBoard) {
+    // Check so that all legal moves returned can be individually verified as legal
+    let board = OthelloBoard::try_from(board).unwrap();
+    let stone = Stone::Black;
+
+    let result = board
+        .legal_moves_for(stone)
+        .positions()
+        .map(|pos| board.is_legal_move(stone, pos))
+        .all(|result| result);
+    assert!(result);
+}
+
+#[quickcheck]
+fn illegal_moves_should_be_illegal(board: ShadowOthelloBoard) {
+    // Check so that all moves not contained in the set of legal moves
+    // actually is illegal
+    let board = OthelloBoard::try_from(board).unwrap();
+    let stone = Stone::Black;
+
+    let legal_positions: HashSet<u64> = board.legal_moves_for(stone).positions().collect();
+
+    let failed = MASKS
+        .iter()
+        .filter(|pos| !legal_positions.contains(pos))
+        .map(|pos| board.is_legal_move(stone, *pos))
+        .any(|result| result);
+
+    assert!(!failed);
+}
+
+#[derive(Debug, Clone)]
+struct ShadowOthelloBoard {
+    black_stones: u64,
+    white_stones: u64,
+}
+
+impl Arbitrary for ShadowOthelloBoard {
+    fn arbitrary(g: &mut Gen) -> ShadowOthelloBoard {
+        // Generate a random bitboard
+        let bits = u64::arbitrary(g);
+
+        let mut black_stones = 0;
+        let mut white_stones = 0;
+
+        // Iterate over all bits
+        for i in 0..63 {
+            // Extract the next bit
+            let next_bit = (bits >> i) & 1;
+            // Arbitrarily assign this bit to either black or white
+            let assign_black = bool::arbitrary(g);
+            if assign_black {
+                black_stones |= next_bit << i;
+            } else {
+                white_stones |= next_bit << i;
+            }
+        }
+        ShadowOthelloBoard::try_from((black_stones, white_stones)).unwrap()
+    }
+}
+
+impl TryFrom<(u64, u64)> for ShadowOthelloBoard {
+    type Error = OthelloError;
+
+    fn try_from(stones: (u64, u64)) -> Result<Self, Self::Error> {
+        let (black_stones, white_stones) = stones;
+        if black_stones & white_stones != 0 {
+            return Err(OthelloError::PiecesOverlapping);
+        }
+        let board = ShadowOthelloBoard {
+            black_stones,
+            white_stones,
+        };
+        Ok(board)
+    }
+}
+
+impl TryFrom<ShadowOthelloBoard> for OthelloBoard {
+    type Error = OthelloError;
+
+    fn try_from(board: ShadowOthelloBoard) -> Result<Self, Self::Error> {
+        OthelloBoard::try_from((board.black_stones, board.white_stones))
+    }
+}


### PR DESCRIPTION
Added quickcheck tests evaluating move generation, move checking and to some extent, move making.

Quickcheck uncovered a bug in the legal move checker. If the position to check legality for is placed on another stone, the checker previously could return true if all other conditions were met. The fix was to simply check whether or not the position is actually free.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>