### PR TITLE
Bitboard positions

### DIFF
--- a/benches/othello_board.rs
+++ b/benches/othello_board.rs
@@ -1,7 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use magpie::othello::OthelloBoard;
-use magpie::othello::PositionExt;
-use magpie::othello::Stone;
+use magpie::othello::{OthelloBoard, SquareExt, Stone, StoneExt};
 use std::convert::TryFrom;
 
 fn bench_clone(c: &mut Criterion) {
@@ -41,7 +39,15 @@ fn bench_legal_moves_extraction(c: &mut Criterion) {
     let board = board_for_legal_moves();
     let moves = board.legal_moves_for(Stone::Black);
     c.bench_function("legal_moves_extraction", |b| {
-        b.iter(|| moves.positions().collect::<Vec<u64>>())
+        b.iter(|| moves.stones().collect::<Vec<u64>>())
+    });
+}
+
+fn bench_square_extraction(c: &mut Criterion) {
+    let board = board_for_legal_moves();
+    let moves = board.legal_moves_for(Stone::Black);
+    c.bench_function("square_extraction", |b| {
+        b.iter(|| moves.squares().collect::<Vec<u64>>())
     });
 }
 
@@ -51,7 +57,8 @@ criterion_group!(
     bench_legal_moves,
     bench_place_stone,
     bench_legal_move_check,
-    bench_legal_moves_extraction
+    bench_legal_moves_extraction,
+    bench_square_extraction
 );
 criterion_main!(benches);
 

--- a/examples/basic_operations.rs
+++ b/examples/basic_operations.rs
@@ -1,4 +1,4 @@
-use magpie::othello::{OthelloBoard, PositionExt, Stone};
+use magpie::othello::{OthelloBoard, Stone, StoneExt};
 use std::convert::TryFrom;
 fn main() {
     // The board can be initialized in a few different ways.
@@ -60,10 +60,10 @@ fn main() {
     // with value 1 is a legal move.
     let legal_moves: u64 = board.legal_moves_for(stone);
     // Since the bitboard might be difficult to work with, magpie defines an
-    // extension trait called `PositionExt`. It extracts all individual bits
+    // extension trait called `StoneExt`. It extracts all individual bits
     // that are set to 1 and returns an iterator, yielding these bits as if
     // they were independent bitboards (i.e with only one bit set).
-    let mut positions = legal_moves.positions();
+    let mut positions = legal_moves.stones();
     // Here it is verified that all legal moves extracted are indeed legal to
     // play.
     assert!(positions.all(|pos| board.is_legal_move(stone, pos)));
@@ -74,7 +74,7 @@ fn main() {
     let stone = Stone::Black;
     let any_move = board
         .legal_moves_for(stone)
-        .positions()
+        .stones()
         .next() // Get the first legal move we find
         .unwrap(); // Errors should be handled in a real application
                    // (I won't tell anyone though)

--- a/examples/human_vs_ai/agent/random_agent.rs
+++ b/examples/human_vs_ai/agent/random_agent.rs
@@ -1,5 +1,5 @@
 use crate::agent::{Action, Agent};
-use magpie::othello::{OthelloBoard, PositionExt, Stone};
+use magpie::othello::{OthelloBoard, Stone, StoneExt};
 use rand::seq::SliceRandom;
 
 /// Plays completely randomly. If no legal moves are available, passes their
@@ -9,7 +9,7 @@ pub struct RandomAgent;
 impl Agent for RandomAgent {
     fn play(&mut self, stone: Stone, board: &OthelloBoard) -> Action {
         let moves = board.legal_moves_for(stone);
-        let segmented_moves: Vec<u64> = moves.positions().collect();
+        let segmented_moves: Vec<u64> = moves.stones().collect();
 
         match segmented_moves.choose(&mut rand::thread_rng()) {
             Some(pos) => Action::Move(*pos),

--- a/src/othello/mod.rs
+++ b/src/othello/mod.rs
@@ -6,5 +6,5 @@ mod othello_board;
 mod stone;
 
 pub use display::{Format, OthelloDisplay};
-pub use othello_board::{OthelloBoard, OthelloError, PositionExt};
+pub use othello_board::{OthelloBoard, OthelloError, SquareExt, StoneExt};
 pub use stone::Stone;

--- a/tests/perft.rs
+++ b/tests/perft.rs
@@ -1,4 +1,4 @@
-use magpie::othello::{OthelloBoard, PositionExt, Stone};
+use magpie::othello::{OthelloBoard, Stone, StoneExt};
 
 macro_rules! perft_tests {
     ($($test_name:ident: $depth:expr,)*) => {
@@ -94,7 +94,7 @@ fn perft(board: &OthelloBoard, stone: Stone, passed: bool, depth: u8) -> u64 {
         }
     } else {
         moves
-            .positions()
+            .stones()
             .map(|pos| {
                 let mut new_board = board.clone();
                 new_board.place_stone(stone, pos).unwrap();

--- a/tests/square_extraction.rs
+++ b/tests/square_extraction.rs
@@ -1,0 +1,9 @@
+use magpie::othello::{SquareExt, StoneExt};
+
+#[test]
+fn full_bitboard_positions_equal_stones() {
+    let v1: Vec<u64> = u64::MAX.squares().collect();
+    let v2: Vec<u64> = u64::MAX.stones().collect();
+
+    assert_eq!(v1, v2);
+}


### PR DESCRIPTION
Renamed `PositionExt` to `StoneExt` and added SquareExt to enumerate all squares on the board. Some tests were added and files across the entire repository were changed to compile with the new changes.

Closes #33

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>