### PR TITLE
Release preparation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magpie"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Emil Englesson <englesson.emil@gmail.com>"]
 edition = "2018"
 description = "Reasonably efficient Othello library built with bitboards"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-magpie = "0.6.0"
+magpie = "0.7.0"
 ```
 
 ## Crate features
@@ -35,7 +35,7 @@ Serialization with [Serde](https://serde.rs/) is not supported by default. If yo
 
 ```toml
 [dependencies]
-magpie = {version = "0.6.0", features = ["serde"]}
+magpie = {version = "0.7.0", features = ["serde"]}
 ```
 
 ## Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! magpie = {version = "0.6.0", features = ["serde"]}
+//! magpie = {version = "0.7.0", features = ["serde"]}
 //! ```
 //!
 //! [`Wikipedia`]: https://en.wikipedia.org/wiki/Bitboard


### PR DESCRIPTION
Bumped version in `Cargo.toml` and related docs.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>