### PR TITLE
Updated naming

### DIFF
--- a/examples/human_vs_ai/main.rs
+++ b/examples/human_vs_ai/main.rs
@@ -19,7 +19,7 @@ fn play() {
 
     let mut board = OthelloBoard::standard();
     let mut passed_last_turn = false;
-    while board.empty_cells().count_ones() > 0 {
+    while board.empty_squares().count_ones() > 0 {
         println!("{}", board.display().with_stone(active_agent.stone()));
         let legal_moves = board.legal_moves_for(active_agent.stone());
         if legal_moves == 0 {

--- a/src/othello/othello_board.rs
+++ b/src/othello/othello_board.rs
@@ -287,7 +287,7 @@ impl OthelloBoard {
     /// println!("{:?} has {} legal moves", stone, board.legal_moves_for(stone).count_ones());
     /// ```
     pub fn legal_moves_for(&self, stone: Stone) -> u64 {
-        let empty_cells = self.empty_cells();
+        let empty_squares = self.empty_squares();
         let current_bits = self.bits_for(stone);
         let opponent_bits = self.bits_for(stone.flip());
 
@@ -295,14 +295,14 @@ impl OthelloBoard {
         for dir in Direction::cardinals() {
             let mut candidates = dir.shift(current_bits) & opponent_bits;
             while candidates != 0 {
-                moves |= empty_cells & dir.shift(candidates);
+                moves |= empty_squares & dir.shift(candidates);
                 candidates = dir.shift(candidates) & opponent_bits;
             }
         }
         moves
     }
 
-    /// Returns the set of all empty cells on the board.
+    /// Returns the set of all empty squares on the board.
     ///
     /// The returned bitboard represents the Othello board. For a more detailed
     /// description, refer to the documentation of the [`OthelloBoard struct`]
@@ -314,9 +314,9 @@ impl OthelloBoard {
     /// use magpie::othello::OthelloBoard;
     ///
     /// let board = OthelloBoard::standard();
-    /// println!("Number of free cells: {}", board.empty_cells().count_ones());
+    /// assert_eq!(60, board.empty_squares().count_ones());
     /// ```
-    pub fn empty_cells(&self) -> u64 {
+    pub fn empty_squares(&self) -> u64 {
         (!self.black_stones) & (!self.white_stones)
     }
 

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -89,7 +89,7 @@ fn bits_should_be_consistent(board: ShadowOthelloBoard) {
 
     let black = board.bits_for(Stone::Black);
     let white = board.bits_for(Stone::White);
-    let empty = board.empty_cells();
+    let empty = board.empty_squares();
 
     assert!(black & white == 0);
     assert!((black | white) & empty == 0);
@@ -102,7 +102,7 @@ fn stone_at_consistency(board: ShadowOthelloBoard, rand_pos: u64) {
 
     let black = board.bits_for(Stone::Black);
     let white = board.bits_for(Stone::White);
-    let empty = board.empty_cells();
+    let empty = board.empty_squares();
 
     // Test all board positions and one random element, that may have multiple
     // bits set


### PR DESCRIPTION
Updated naming for `empty_cells()` to `empty_squares()` to better reflect the newly introduced `SquareExt`, where each position on the board is referred to as a "square", like in chess or checkers.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>