### PR TITLE
Release preparation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magpie"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Emil Englesson <englesson.emil@gmail.com>"]
 edition = "2018"
 description = "Reasonably efficient Othello library built with bitboards"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-magpie = "0.7.0"
+magpie = "0.8.0"
 ```
 
 ## Crate features
@@ -35,7 +35,7 @@ Serialization with [Serde](https://serde.rs/) is not supported by default. If yo
 
 ```toml
 [dependencies]
-magpie = {version = "0.7.0", features = ["serde"]}
+magpie = {version = "0.8.0", features = ["serde"]}
 ```
 
 ## Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! magpie = {version = "0.7.0", features = ["serde"]}
+//! magpie = {version = "0.8.0", features = ["serde"]}
 //! ```
 //!
 //! [`Wikipedia`]: https://en.wikipedia.org/wiki/Bitboard

--- a/src/othello/othello_board.rs
+++ b/src/othello/othello_board.rs
@@ -1,5 +1,7 @@
-use crate::direction::Direction;
-use crate::othello::{display::OthelloDisplay, Stone};
+use crate::{
+    direction::Direction,
+    othello::{display::OthelloDisplay, Stone},
+};
 use std::convert::TryFrom;
 
 #[cfg(feature = "serde")]
@@ -534,7 +536,7 @@ pub trait SquareExt: Sized {
     /// ```text
     /// 100    010    001    000    000    000    000    000    000
     /// 000 => 000 => 000 => 000 => 000 => 000 => 000 => 000 => 000
-    /// 000    000    000    000    000    000    100    000    000
+    /// 000    000    000    000    000    000    100    010    001
     /// ```
     /// The iterator always return 64 bitboards since Othello has 64 positions.
     ///


### PR DESCRIPTION
Bumped version in `Cargo.toml` and related docs. Also, fixed an unrelated docs error for `SquareExt`.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>