### PR TITLE
Release preparation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magpie"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Emil Englesson <englesson.emil@gmail.com>"]
 edition = "2018"
 description = "Reasonably efficient Othello library built with bitboards"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ unicode-segmentation = "1.7.1"
 serde_json = "1.0.60"
 quickcheck = "1.0.2"
 quickcheck_macros = "1.0.0"
-lazy_static = "1.4.0"
 indoc = "1.0.3"
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-magpie = "0.8.0"
+magpie = "0.9.0"
 ```
 
 ## Crate features
@@ -35,7 +35,7 @@ Serialization with [Serde](https://serde.rs/) is not supported by default. If yo
 
 ```toml
 [dependencies]
-magpie = {version = "0.8.0", features = ["serde"]}
+magpie = {version = "0.9.0", features = ["serde"]}
 ```
 
 ## Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! magpie = {version = "0.8.0", features = ["serde"]}
+//! magpie = {version = "0.9.0", features = ["serde"]}
 //! ```
 //!
 //! [`Wikipedia`]: https://en.wikipedia.org/wiki/Bitboard


### PR DESCRIPTION
Removed `lazy-static` as its usecase is now covered by magpie itself.

Bumped version in `Cargo.toml` and related docs.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>