### PR TITLE
Add #[must_use]

### DIFF
--- a/src/othello/bitboard.rs
+++ b/src/othello/bitboard.rs
@@ -23,6 +23,7 @@ impl Bitboard {
     /// let b: Bitboard = 0.into();
     /// assert_eq!(b.raw(), 0);
     /// ```
+    #[must_use]
     pub fn raw(self) -> u64 {
         self.0
     }
@@ -36,6 +37,7 @@ impl Bitboard {
     /// let b: Bitboard = 0.into();
     /// assert!(b.is_empty());
     /// ```
+    #[must_use]
     pub fn is_empty(self) -> bool {
         self.0 == 0
     }
@@ -49,6 +51,7 @@ impl Bitboard {
     /// let b: Bitboard = u64::MAX.into();
     /// assert_eq!(b.count_set(), 64);
     /// ```
+    #[must_use]
     pub fn count_set(self) -> u8 {
         self.0.count_ones().try_into().unwrap()
     }
@@ -62,6 +65,7 @@ impl Bitboard {
     /// let b: Bitboard = u64::MAX.into();
     /// assert_eq!(b.count_empty(), 0);
     /// ```
+    #[must_use]
     pub fn count_empty(self) -> u8 {
         self.0.count_zeros().try_into().unwrap()
     }
@@ -91,6 +95,7 @@ impl Bitboard {
     /// let b: Bitboard = 0.into();
     /// assert_eq!(b.bits().len(), 64);
     ///  ```
+    #[must_use]
     pub fn bits(self) -> impl ExactSizeIterator<Item = Bitboard> {
         POSITIONS.iter().map(move |m| self & *m)
     }
@@ -119,6 +124,7 @@ impl Bitboard {
     /// let b: Bitboard = u64::from(u32::MAX).into();
     /// assert_eq!(b.hot_bits().len(), 32);
     ///  ```
+    #[must_use]
     pub fn hot_bits(self) -> impl ExactSizeIterator<Item = Position> {
         let positions = HotBits {
             remaining: self.count_set(),

--- a/src/othello/board.rs
+++ b/src/othello/board.rs
@@ -73,6 +73,7 @@ impl Board {
     /// let board = Board::empty();
     /// assert_eq!(64, board.empty_squares().count_set());
     /// ```
+    #[must_use]
     pub fn empty() -> Self {
         Self {
             black_stones: 0.into(),
@@ -104,6 +105,7 @@ impl Board {
     /// let board = Board::standard();
     /// assert_eq!(60, board.empty_squares().count_set());
     /// ```
+    #[must_use]
     pub fn standard() -> Self {
         Self {
             black_stones: BLACK_START_POS.into(),
@@ -245,6 +247,7 @@ impl Board {
     /// // The two bitboards do not intersect
     /// assert_eq!(0, black & white);
     /// ```
+    #[must_use]
     pub fn bits_for(&self, stone: Stone) -> Bitboard {
         match stone {
             Stone::Black => self.black_stones,
@@ -265,6 +268,7 @@ impl Board {
     /// let pos = 1_u64.try_into().unwrap();
     /// assert!(!board.is_legal_move(Stone::Black, pos));
     /// ```
+    #[must_use]
     pub fn is_legal_move(&self, stone: Stone, pos: Position) -> bool {
         let pos = Bitboard::from(pos);
         let current_bits = self.bits_for(stone);
@@ -309,6 +313,7 @@ impl Board {
     /// let stone = Stone::Black;
     /// assert_eq!(4, board.moves_for(stone).count_set());
     /// ```
+    #[must_use]
     pub fn moves_for(&self, stone: Stone) -> Bitboard {
         let current_bits = self.bits_for(stone);
         let opponent_bits = self.bits_for(stone.flip());
@@ -352,6 +357,7 @@ impl Board {
     /// let board = Board::standard();
     /// assert_eq!(60, board.empty_squares().count_set());
     /// ```
+    #[must_use]
     pub fn empty_squares(&self) -> Bitboard {
         !(self.black_stones | self.white_stones)
     }
@@ -369,6 +375,7 @@ impl Board {
     /// let pos = 0x8000000.try_into().unwrap();
     /// assert_eq!(Some(Stone::White), board.stone_at(pos));
     ///  ```
+    #[must_use]
     pub fn stone_at(&self, pos: Position) -> Option<Stone> {
         if self.black_stones & pos > 0 {
             Some(Stone::Black)
@@ -393,6 +400,7 @@ impl Board {
     /// let board = Board::standard();
     /// println!("{}", board.display());
     ///  ```
+    #[must_use]
     pub fn display(&self) -> BoardDisplay {
         BoardDisplay::new(self)
     }

--- a/src/othello/display.rs
+++ b/src/othello/display.rs
@@ -60,6 +60,7 @@ impl<'a> BoardDisplay<'a> {
     /// let board = Board::standard();
     /// println!("{}", board.display().with_stone(Stone::Black));
     /// ```
+    #[must_use]
     pub fn with_stone(&self, stone: Stone) -> Self {
         Self {
             board: self.board,
@@ -77,6 +78,7 @@ impl<'a> BoardDisplay<'a> {
     /// let board = Board::standard();
     /// println!("{}", board.display().with_format(Format::Compact));
     /// ```
+    #[must_use]
     pub fn with_format(&self, display: Format) -> Self {
         Self {
             board: self.board,

--- a/src/othello/position.rs
+++ b/src/othello/position.rs
@@ -68,6 +68,7 @@ impl Position {
     /// let p: Position = (1 << 32).try_into().unwrap();
     /// assert_eq!(p.raw(), (1 << 32));
     /// ```
+    #[must_use]
     pub fn raw(self) -> u64 {
         self.0
     }
@@ -88,6 +89,7 @@ impl Position {
     /// ```
     ///
     /// [`Position`]: crate::othello::Position
+    #[must_use]
     pub fn rank(self) -> u8 {
         (self.0.leading_zeros() / 8).try_into().unwrap()
     }
@@ -108,6 +110,7 @@ impl Position {
     /// ```
     ///
     /// [`Position`]: crate::othello::Position
+    #[must_use]
     pub fn file(self) -> u8 {
         (self.0.leading_zeros() % 8).try_into().unwrap()
     }
@@ -127,6 +130,7 @@ impl Position {
     /// ```
     ///
     /// [`Position`]: crate::othello::Position
+    #[must_use]
     pub fn to_notation(self) -> String {
         POSITIONS_AS_NOTATION[self.0.leading_zeros() as usize].to_string()
     }

--- a/src/othello/stone.rs
+++ b/src/othello/stone.rs
@@ -18,6 +18,7 @@ impl Stone {
     ///
     /// assert_eq!(Stone::White, Stone::Black.flip());
     /// ```
+    #[must_use]
     pub fn flip(&self) -> Self {
         match &self {
             Self::Black => Self::White,


### PR DESCRIPTION
The API surface is a mix of mutating and non-mutating functions which makes them easy to mix up. It makes sense for the compiler to warn users when they potentially misuse the API.

Closes #50 