### PR TITLE
Small dependency fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,8 @@ exclude = [
 serde = { version = "1", optional = true, features = ["derive"] }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 rand = "0.8"
-unicode-segmentation = "1.7"
 serde_json = "1.0"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -1,5 +1,4 @@
 use magpie::othello::{Board, Stone};
-#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use serde_json::Result;
 


### PR DESCRIPTION
- Updated `criterion` to 0.4
- Removed `unicode-segmentation`. It should have been removed in #51.
- Removed redundant `#[cfg(feature = "serde")]` in a test.