### PR TITLE
Release preparation for v0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magpie"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Emil Englesson <englesson.emil@gmail.com>"]
 edition = "2021"
 description = "Reasonably efficient Othello library built with bitboards"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Alternatively, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-magpie = "0.9.0"
+magpie = "0.10"
 ```
 
 ## Crate features
@@ -41,7 +41,7 @@ Serialization with [Serde](https://serde.rs/) is not supported by default. If yo
 
 ```toml
 [dependencies]
-magpie = {version = "0.9.0", features = ["serde"]}
+magpie = {version = "0.10", features = ["serde"]}
 ```
 
 ## Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! magpie = {version = "0.9.0", features = ["serde"]}
+//! magpie = {version = "0.10", features = ["serde"]}
 //! ```
 //!
 //! [`Serde`]: https://serde.rs


### PR DESCRIPTION
Bumped version in `Cargo.toml` and related docs.
