### PR TITLE
Modernization of CI/CD workflows and minor documentation touchups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,10 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Build project
+      - name: Build
         run: |
           cargo build --all-targets
           cargo build --all-targets --features serde
@@ -23,14 +19,10 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Run tests
+      - name: Test
         run: |
           cargo test
           cargo test --features serde
@@ -39,13 +31,8 @@ jobs:
     name: fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,75 +2,36 @@ name: Publish
 
 on:
   workflow_dispatch:
-    inputs:
-      create-tag:
-        description: 'Create and push a new tag'
-        required: true
-        type: boolean
-      publish-crate:
-        description: 'Publish a new version to crates.io'
-        required: true
-        type: boolean
 
 jobs:
-  extract-info:
+  orchestrate-release:
     runs-on: ubuntu-latest
     outputs:
-      crate_version: ${{ steps.info.outputs.crate_version }}
-      crate_name: ${{ steps.info.outputs.crate_name }}
+      run_publish: ${{ steps.release.outputs.run_publish }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Extract info
-        id: info
-        # https://github.com/rust-cli/meta/issues/33
-        # Thanks ashutoshrishi!
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Create new release
+        id: release
         run: |
-          CRATE_NAME=$(awk -F ' = ' '$1 ~ /name/ { gsub(/["]/, "", $2); printf("%s",$2); exit }' Cargo.toml)
-          CRATE_VERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/["]/, "", $2); printf("%s",$2); exit }' Cargo.toml)
-          CRATE_VERSION="v${CRATE_VERSION}"
-
-          echo "Detected crate: ${CRATE_NAME}@${CRATE_VERSION}"
-
-          echo "::set-output name=crate_version::${CRATE_VERSION}"
-          echo "::set-output name=crate_name::${CRATE_NAME}"
-
-  push-tag:
-    if: ${{ inputs.create-tag }}
-    needs: extract-info
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Create and push new tag
-        id: tag
-        # https://github.com/rust-cli/meta/issues/33
-        # Thanks ashutoshrishi!
-        run: |
-          VERSION=${{needs.extract-info.outputs.crate_version}}
-
-          echo "Creating tag: ${VERSION}"
-          git config --global user.name '${{ secrets.GIT_USERNAME }}'
-          git config --global user.email '${{ secrets.GIT_EMAIL }}'
-          git tag -a ${VERSION} -m ''
-          git push origin refs/tags/${VERSION}
+          cargo install cargo-extract
+          VERSION=v$(cargo extract package.version)
+          echo "Creating release: ${VERSION}"
+          gh release create ${VERSION} --title ${VERSION}
+          echo "run_publish=true" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish:
-    # This convoluted if statement will ensure that this
-    # job may run even if the "push-tag" job is skipped
-    if: always() &&
-        (needs.push-tag.result == 'success' || needs.push-tag.result == 'skipped') &&
-        inputs.publish-crate
-    needs: [push-tag, extract-info]
+    needs: [orchestrate-release]
+    if: needs.orchestrate-release.outputs.run_publish == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Install latest stable
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Publish to crates.io
-        run: cargo publish --token $SECRET_TOKEN
+        run: cargo publish
         env:
-          SECRET_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
-![CI status](https://github.com/LimeEng/magpie/workflows/CI/badge.svg)
+[![CI status](https://github.com/LimeEng/magpie/actions/workflows/ci.yml/badge.svg)](https://github.com/LimeEng/magpie/actions/workflows/ci.yml)
 [![Latest version](https://img.shields.io/crates/v/magpie.svg)](https://crates.io/crates/magpie)
 
 # Magpie
 
-<img src="https://limeeng.github.io/cdn/repo/magpie/logo.svg" width="200" align="right">
+<img src="https://cdn.github.emileng.se/repo/magpie/logo.svg" width="200" align="right">
 
-Magpie is a simple [Othello](https://en.wikipedia.org/wiki/Reversi) library written in Rust. Othello is a perfect information, zero-sum game for two players.
+Magpie is a simple [Othello](https://en.wikipedia.org/wiki/Reversi) library. Othello is a perfect information, zero-sum game for two players.
 
 Magpie is built with bitboards which allows for extremely fast updates and queries. Two abstraction levels are available, the higher level [`Game`] and lower-level [`Board`]. The [`Game`]-struct guarantees that only legal moves will be made and that the board will be kept consistent. The drawback is that it is not as flexible as the alternative, or as performant. The [`Board`]-struct does not keep track of whose turn it is, whether a player passed their turn, or validates inputs, which makes it better suited for engines.
-
-Magpie is built with bitboards which allows for extremely fast updates and queries. Two abstraction levels are available. The higher abstraction level guarantees that only legal moves will be made and that the board will be kept consistent. The drawback is that it is not as flexible or performant as the alternative. The lower abstraction level does not keep track of whose turn it is, whether a player passed their turn, or validates inputs, which makes it better suited for engines.
 
 ## Table of Contents
 - [Documentation](#documentation)
@@ -27,7 +25,7 @@ Documentation is hosted on [docs.rs](https://docs.rs/magpie/)
 Simply run:
 
 ```
-cargo add magpie
+$ cargo add magpie
 ```
 
 Alternatively, add this to your `Cargo.toml`:
@@ -53,7 +51,7 @@ Examples are [found here](/examples).
 Included as an example is a functional game which allows you to play Othello against a random AI. To start the game, run the following command:
 
 ```
-cargo run --example human_vs_ai
+$ cargo run --example human_vs_ai
 ```
 
 ## Benchmarks

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 ## Human vs AI
 
 ```
-cargo run --example human_vs_ai
+$ cargo run --example human_vs_ai
 ```
 
 This example allows you to play Othello against an AI that plays random legal moves. It demonstrates a possible use for the higher-level `Game`-struct.
@@ -11,7 +11,7 @@ This example allows you to play Othello against an AI that plays random legal mo
 ## Board operations
 
 ```
-cargo run --example board_operations
+$ cargo run --example board_operations
 ```
 
 Usage of the lower-level `Board`-struct is demonstrated here, suitable for use with engines.
@@ -19,7 +19,7 @@ Usage of the lower-level `Board`-struct is demonstrated here, suitable for use w
 ## Serde
 
 ```
-cargo run --example serde --features serde
+$ cargo run --example serde --features serde
 ```
 
 Serialization with [Serde](https://serde.rs/) is not supported by default but it is possible to opt into using magpie with serde by enabling the appropriately named feature flag. This example demonstrates how serde can be used to both serialize and deserialize a custom struct containing magpie-structures.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_logo_url = "https://limeeng.github.io/cdn/repo/magpie/logo.svg")]
+#![doc(html_logo_url = "https://cdn.github.emileng.se/repo/magpie/logo.svg")]
 
 //! Magpie is a reasonably efficient Othello library.
 //!


### PR DESCRIPTION
- Modernized the workflows. Specifically, `actions-rs/toolchain` has been archived and has thus been replaced by `dtolnay/rust-toolchain@stable`.
- Removed duplicate docs.
- The link that referenced the logo has been updated.
- Updated badges to the new format.
- Added a dollar sign in front of console commands in the documentation.