### PR TITLE
Release preparation for v0.11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magpie"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Emil Englesson <englesson.emil@gmail.com>"]
 edition = "2021"
 description = "Reasonably efficient Othello library built with bitboards"


### PR DESCRIPTION
Bumped version in `Cargo.toml`.